### PR TITLE
Possible to clear factory cache

### DIFF
--- a/src/FactoryLocator.php
+++ b/src/FactoryLocator.php
@@ -89,6 +89,8 @@ final class FactoryLocator
             self::$candidates[$factoryInterface],
             [$factoryImplementation]
         );
+
+        HttpFactory::clearCache($factoryInterface);
     }
 
     /**

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -56,4 +56,13 @@ final class HttpFactory
 
         return self::$factories[$factoryInterface];
     }
+
+    public static function clearCache(?string $factoryInterface = null): void
+    {
+        if ($factoryInterface === null) {
+            self::$factories = [];
+        } else {
+            unset(self::$factories[$factoryInterface]);
+        }
+    }
 }


### PR DESCRIPTION
When testing what happens when a factory implementation is registered, and then what happens when it is not registered, there must be a way to clear the factory implementation cache.