### PR TITLE
Make cache reusable

### DIFF
--- a/src/DiscoveryCache.php
+++ b/src/DiscoveryCache.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Http\Factory\Discovery;
+
+use RuntimeException;
+
+abstract class DiscoveryCache
+{
+    /** @var array */
+    private static $cache = [];
+
+    protected static function instance(string $interface)
+    {
+        if (! isset(self::$cache[$interface])) {
+            $implementation = static::locate($interface);
+            self::$cache[$interface] = new $implementation();
+        }
+
+        return self::$cache[$interface];
+    }
+
+    public static function clearCache(?string $interface = null): void
+    {
+        if ($interface === null) {
+            self::$cache = [];
+        } else {
+            unset(self::$cache[$interface]);
+        }
+    }
+
+    /**
+     * @throws RuntimeException If no implementation is available
+     */
+    abstract protected static function locate(string $interface): string;
+}

--- a/src/DiscoveryCache.php
+++ b/src/DiscoveryCache.php
@@ -10,7 +10,7 @@ abstract class DiscoveryCache
     /** @var array */
     private static $cache = [];
 
-    protected static function instance(string $interface)
+    protected static function makeInstance(string $interface)
     {
         if (! isset(self::$cache[$interface])) {
             $implementation = static::locate($interface);

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -14,32 +14,32 @@ final class HttpFactory extends DiscoveryCache
 {
     public static function requestFactory(): RequestFactoryInterface
     {
-        return self::instance(RequestFactoryInterface::class);
+        return self::makeInstance(RequestFactoryInterface::class);
     }
 
     public static function responseFactory(): ResponseFactoryInterface
     {
-        return self::instance(ResponseFactoryInterface::class);
+        return self::makeInstance(ResponseFactoryInterface::class);
     }
 
     public static function serverRequestFactory(): ServerRequestFactoryInterface
     {
-        return self::instance(ServerRequestFactoryInterface::class);
+        return self::makeInstance(ServerRequestFactoryInterface::class);
     }
 
     public static function streamFactory(): StreamFactoryInterface
     {
-        return self::instance(StreamFactoryInterface::class);
+        return self::makeInstance(StreamFactoryInterface::class);
     }
 
     public static function uploadedFileFactory(): UploadedFileFactoryInterface
     {
-        return self::instance(UploadedFileFactoryInterface::class);
+        return self::makeInstance(UploadedFileFactoryInterface::class);
     }
 
     public static function uriFactory(): UriFactoryInterface
     {
-        return self::instance(UriFactoryInterface::class);
+        return self::makeInstance(UriFactoryInterface::class);
     }
 
     protected static function locate(string $interface): string

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -3,66 +3,47 @@ declare(strict_types=1);
 
 namespace Http\Factory\Discovery;
 
-use InvalidArgumentException;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
-use RuntimeException;
 
-final class HttpFactory
+final class HttpFactory extends DiscoveryCache
 {
-    /** @var array */
-    private static $factories = [];
-
     public static function requestFactory(): RequestFactoryInterface
     {
-        return self::factoryInstance(RequestFactoryInterface::class);
+        return self::instance(RequestFactoryInterface::class);
     }
 
     public static function responseFactory(): ResponseFactoryInterface
     {
-        return self::factoryInstance(ResponseFactoryInterface::class);
+        return self::instance(ResponseFactoryInterface::class);
     }
 
     public static function serverRequestFactory(): ServerRequestFactoryInterface
     {
-        return self::factoryInstance(ServerRequestFactoryInterface::class);
+        return self::instance(ServerRequestFactoryInterface::class);
     }
 
     public static function streamFactory(): StreamFactoryInterface
     {
-        return self::factoryInstance(StreamFactoryInterface::class);
+        return self::instance(StreamFactoryInterface::class);
     }
 
     public static function uploadedFileFactory(): UploadedFileFactoryInterface
     {
-        return self::factoryInstance(UploadedFileFactoryInterface::class);
+        return self::instance(UploadedFileFactoryInterface::class);
     }
 
     public static function uriFactory(): UriFactoryInterface
     {
-        return self::factoryInstance(UriFactoryInterface::class);
+        return self::instance(UriFactoryInterface::class);
     }
 
-    private static function factoryInstance(string $factoryInterface)
+    protected static function locate(string $interface): string
     {
-        if (! isset(self::$factories[$factoryInterface])) {
-            $factory = FactoryLocator::locate($factoryInterface);
-            self::$factories[$factoryInterface] = new $factory();
-        }
-
-        return self::$factories[$factoryInterface];
-    }
-
-    public static function clearCache(?string $factoryInterface = null): void
-    {
-        if ($factoryInterface === null) {
-            self::$factories = [];
-        } else {
-            unset(self::$factories[$factoryInterface]);
-        }
+        return FactoryLocator::locate($interface);
     }
 }


### PR DESCRIPTION
Extract the cache functionality to an abstract class that automatically brings caching functionality to any type of discovery.