### PR TITLE
Http client discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,19 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+before_install:
+  - chmod +x scripts/test-all-client
+  - chmod +x scripts/test-all-factory
+
 before_script:
   - composer update -n ${COMPOSER_FLAGS}
 
 script:
   - composer analyze
   - composer check
-  - composer test-all
+  - composer test-all-client
+  - composer test-all-factory
+  - composer test
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,14 @@
     "keywords": [
         "discovery",
         "factory",
+        "client",
         "http",
         "psr-7",
         "psr7",
         "psr-17",
-        "psr17"
+        "psr17",
+        "psr-18",
+        "psr18"
     ],
     "type": "library",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,12 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.1",
+        "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0"
     },
     "require-dev": {
         "nyholm/psr7": "^1.0",
+        "php-http/guzzle6-adapter": "^2.0",
         "phpstan/phpstan": "^0.10.3",
         "phpstan/phpstan-phpunit": "^0.10.0",
         "phpunit/phpunit": "^7.3",
@@ -39,6 +41,7 @@
         "http-interop/http-factory-guzzle": "HTTP Factory implementation for Guzzle",
         "http-interop/http-factory-slim": "HTTP Factory implementation for Slim",
         "nyholm/psr7": "HTTP Messages with Factory implementation",
+        "php-http/guzzle6-adapter": "HTTP Client implementation for Guzzle",
         "zendframework/zend-diactoros": "HTTP Messages with Factory implementation"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,9 @@
         "analyze": "phpstan analyse -l 7 --no-progress src tests",
         "check": "phpcs",
         "test": "phpunit --testdox",
-        "test-all": "scripts/test-all"
+        "test-factory": "phpunit --testsuite factory --testdox",
+        "test-all-factory": "scripts/test-all-factory",
+        "test-client": "phpunit --testsuite client --testdox",
+        "test-all-client": "scripts/test-all-client"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,14 @@
         <testsuite name="default">
             <directory>tests/</directory>
         </testsuite>
+        <testsuite name="factory">
+            <directory>tests/FactoryLocatorTest.php</directory>
+            <directory>tests/HttpFactoryTest.php</directory>
+        </testsuite>
+        <testsuite name="client">
+            <directory>tests/ClientLocatorTest.php</directory>
+            <directory>tests/HttpClientTest.php</directory>
+        </testsuite>
     </testsuites>
     <filter>
         <whitelist>

--- a/scripts/test-all-client
+++ b/scripts/test-all-client
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [ -z "$COMPOSER_FLAGS" ]; then
+    COMPOSER_FLAGS=
+fi
+
+echo "Backing up package state ..."
+composerBackup=$(cat composer.json)
+
+composer remove --dev -n nyholm/psr7 php-http/guzzle6-adapter
+
+testImplementation() {
+    echo "Testing $1 version $2 ..."
+    echo
+    composer require --dev -n $COMPOSER_FLAGS "$1" "$2"
+    composer test-client || return 1
+    composer remove --dev -n "$1"
+    echo
+    return 0
+}
+
+testImplementation php-http/guzzle6-adapter "^2.0" || exit 1
+
+echo "Resetting package state ..."
+echo "$composerBackup" > composer.json
+composer update -n -q $COMPOSER_FLAGS

--- a/scripts/test-all-factory
+++ b/scripts/test-all-factory
@@ -4,11 +4,16 @@ if [ -z "$COMPOSER_FLAGS" ]; then
     COMPOSER_FLAGS=
 fi
 
+echo "Backing up package state ..."
+composerBackup=$(cat composer.json)
+
+composer remove --dev -n nyholm/psr7 php-http/guzzle6-adapter
+
 testImplementation() {
     echo "Testing $1 version $2 ..."
     echo
     composer require --dev -n $COMPOSER_FLAGS "$1" "$2"
-    composer test || return 1
+    composer test-factory || return 1
     composer remove --dev -n "$1"
     echo
     return 0
@@ -20,8 +25,6 @@ testImplementation http-interop/http-factory-guzzle "^1.0" || exit 1
 testImplementation http-interop/http-factory-slim "^1.0" || exit 1
 testImplementation zendframework/zend-diactoros "^2.0" || exit 1
 
-if [ -z "$TRAVIS" ]; then
-    echo "Resetting package state ..."
-    git checkout -- composer.json
-    composer -n -q update
-fi
+echo "Resetting package state ..."
+echo "$composerBackup" > composer.json
+composer update -n -q $COMPOSER_FLAGS

--- a/src/ClientLocator.php
+++ b/src/ClientLocator.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Http\Factory\Discovery;
+
+use Psr\Http\Client\ClientInterface;
+
+final class ClientLocator extends DiscoveryLocator
+{
+    /** @var array  */
+    protected static $candidates = [
+        ClientInterface::class => [
+            'Http\Adapter\Guzzle6\Client',
+            'Http\Adapter\Guzzle5\Client',
+            'Http\Client\Curl\Client',
+            'Http\Client\Socket\Client',
+            'Http\Adapter\React\Client',
+            'Http\Adapter\Buzz\Client',
+            'Http\Adapter\Cake\Client',
+            'Http\Adapter\Zend\Client',
+            'Http\Adapter\Artax\Client',
+        ],
+    ];
+    
+    protected static function clearCache(?string $interface = null): void
+    {
+        HttpClient::clearCache($interface);
+    }
+}

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Http\Factory\Discovery;
+
+use Psr\Http\Client\ClientInterface;
+
+final class HttpClient extends DiscoveryCache
+{
+    public static function client(): ClientInterface
+    {
+        return self::makeInstance(ClientInterface::class);
+    }
+
+    protected static function locate(string $interface): string
+    {
+        return ClientLocator::locate($interface);
+    }
+}

--- a/tests/ClientLocatorTest.php
+++ b/tests/ClientLocatorTest.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace Http\Factory\Discovery;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+
+class ClientLocatorTest extends TestCase
+{
+    public function dataClientInterfaces(): array
+    {
+        return [
+            ClientInterface::class => [ClientInterface::class],
+        ];
+    }
+
+    /**
+     * @dataProvider dataClientInterfaces
+     */
+    public function testCanRegisterAdditionalClientsForLocation(string $interface): void
+    {
+        $client = $this->getMockBuilder($interface)->getMock();
+        $clientClass = get_class($client);
+
+        ClientLocator::register($interface, $clientClass);
+
+        $this->assertSame($clientClass, ClientLocator::locate($interface));
+
+        ClientLocator::unregister($interface, $clientClass);
+
+        $this->assertNotSame($clientClass, ClientLocator::locate($interface));
+    }
+
+    public function testCannotRegisterInvalidClient(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo');
+
+        ClientLocator::register('foo', self::class);
+    }
+
+    public function testCannotRegisterInvalidClientImlementation(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(self::class);
+
+        ClientLocator::register(ClientInterface::class, self::class);
+    }
+
+    public function testCannotUnregisterInvalidClient(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo');
+
+        ClientLocator::unregister('foo', self::class);
+    }
+
+    public function testCannotUnregisterInvalidClientImplementation(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(self::class);
+
+        ClientLocator::unregister(ClientInterface::class, self::class);
+    }
+
+    public function testCannotLocateInvalidClient(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        ClientLocator::locate('foo');
+    }
+}

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Http\Factory\Discovery;
+
+use PHPUnit\Framework\TestCase;
+
+class HttpClientTest extends TestCase
+{
+    public function testCanDiscoverClient(): void
+    {
+        $this->assertSame(HttpClient::client(), HttpClient::client());
+    }
+}


### PR DESCRIPTION
Make it possible to discover PSR-18 HTTP Client implementations.

Solves https://github.com/http-interop/http-factory-discovery/issues/6.

This pull request depends on https://github.com/http-interop/http-factory-discovery/pull/7 and https://github.com/http-interop/http-factory-discovery/pull/8.

There is currently only one HTTP Client implementation that works: `Http\Adapter\Guzzle6\Client`. But the following implementations will also start working when/if they are updated to support PSR-18:
- `Http\Adapter\Guzzle5\Client`
- `Http\Client\Curl\Client`
- `Http\Client\Socket\Client`
- `Http\Adapter\React\Client`
- `Http\Adapter\Buzz\Client`
- `Http\Adapter\Cake\Client`
- `Http\Adapter\Zend\Client`
- `Http\Adapter\Artax\Client`
